### PR TITLE
Added Dockerfile and basic run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+
+COPY . /app
+
+RUN pip install -r /app/requirements.txt
+
+EXPOSE 5000/tcp

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Script to run AlgoVision in a docker container
+
+docker_run_AlgoVision() {
+	# Check if docker is installed
+	if ! which docker &>/dev/null
+	then
+		echo "Error: docker not installed"
+		echo "Install instructions: https://docs.docker.com/get-docker/"
+		return 1
+	# Check if algovision image has been built
+	elif ! docker images | grep -q 'algovision'
+	then
+		docker build -t algovision .
+	fi
+
+	# Run algovision image forwarding internal port 5000 to local port 5000
+	docker run -p 5000:5000 algovision python /app/run.py
+	return $?
+}
+
+# Call main function
+docker_run_AlgoVision


### PR DESCRIPTION
Addresses #4 

Here is a first revision Dockerfile and run_script. It will allow Mac/Windows/Linux .... any user on any OS with Docker installed to run this web-server without needing python or any of the dependencies. It will also allow developers to develop within the Docker container without needing to install dependencies on their local machines. 

Docker is quite popular these days, makes applications (especially web applications) very portable. We may want to create an official [Docker Hub](https://hub.docker.com/) image for this in the future, but for now this should do.

To test it out simply: `run_docker.sh`